### PR TITLE
Fix uninitialized G variable in Get_G_C_MTX

### DIFF
--- a/src/ReadInputFiles.cpp
+++ b/src/ReadInputFiles.cpp
@@ -208,6 +208,7 @@ void Get_G_C_MTX(string in_file, int &N_rows, int &G, int &C, map<int,int> &gene
 		expressed_genes[g] = 0;
 	
 	// Read following rows rest of
+    G=0;
     while ( (retval = fgets(ss,1024,infp) ) != NULL) {
 		// Read values gene idx and add as expressed
 		token = strtok(retval," \t");


### PR DESCRIPTION
`G` variable in `Get_G_C_MTX` function is uninitialized, so when I run Sanity on an mtx file I get the following error:

```
File type : mtx
There were 28096 rows
There were -2147455552 genes and 40164 cells
terminate called after throwing an instance of 'std::bad_array_new_length'
  what():  std::bad_array_new_length
Aborted (core dumped)
```

This PR adds one line that initializes it.