### PR TITLE
Fixed a bug in reading mtx-files in float-format and added a mode for running with maximum posterior gene-variance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The scripts used for running the bechmarked normalization methods and for making
 * variance.txt : Estimated variance of the LTQs *x<sub>gc</sub>* across cells *c* for each gene *g*. Note that these variances are different, and generally larger, than what one would obtain when directly calculating the variance of the estimates of *x<sub>gc</sub>* from the file log_transcription_quotients.txt. This is because the estimates in this file take into account the uncertainty on the estimates of the *x<sub>gc</sub>*. Thus, when estimates of true gene expression variability are needed, you are strongly adviced to use the results in this file.
 * delta.txt : Matrix of inferred log-fold changes *&delta;<sub>gc</sub> = x<sub>gc</sub>-&mu;<sub>g</sub>* for each gene *g* in each cell *c*.
 * d_delta.txt : Matrix of error-bars for the inferred log fold-changes *&delta;<sub>gc</sub>*.
-* ..._vmax.txt: All the above files will be obtained with a `_vmax.txt`-suffix when `-max v` is set to `true` or `only_max_output`.
+* ..._vmax.txt: All the above files will be obtained with a `_vmax.txt`-suffix when `-max_v` is set to `true` or `only_max_output`.
 * likelihood.txt : This file encodes the posterior distribution of each gene’s true variance in log-expression. For the numerical calculation of this distribution, the variance is a prior assumed to lie in the range *[v<sub>min</sub>,v<sub>max</sub>]* and is discretized into *N<sub>b</sub>* bins uniformly on a logarithmic scale. The file contains the matrix with posterior values *P<sub>gb</sub>* for each gene *g* and each bin *b*.
 
   | | | | | |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the Poisson noise on the UMI count matrix *n<sub>gc</sub>* of gene *g* in cell *
 
 
 ### Reproducibility
-The raw UMI count and normalized datasets mentionned in benchmarking in the associated [publication](https://www.nature.com/articles/s41587-021-00875-x) are available on [![DO I](https://zenodo.org/badge/DOI/10.5281/zenodo.4009187.svg)](https://zenodo.org/record/4009187). Files are named [*dataset name*]\_UMI\_counts.txt.gz and [*dataset name*]\_[*tool name*]\_normalization.txt.gz.
+The raw UMI count and normalized datasets mentioned in benchmarking in the associated [publication](https://www.nature.com/articles/s41587-021-00875-x) are available on [![DO I](https://zenodo.org/badge/DOI/10.5281/zenodo.4009187.svg)](https://zenodo.org/record/4009187). Files are named [*dataset name*]\_UMI\_counts.txt.gz and [*dataset name*]\_[*tool name*]\_normalization.txt.gz.
 
 The scripts used for running the bechmarked normalization methods and for making the figures of the preprint are in the reproducibility folder.
 
@@ -31,6 +31,7 @@ The scripts used for running the bechmarked normalization methods and for making
 * (optional) Destination folder (`'path/to/output/folder'`, default: `pwd`)
 * (optional) Number of threads (integer, default: `4`)
 * (optional) Print extended output (Boolean, `'true', 'false', '1'` or `'0'`, default: `false`)
+* (optional) Print additional output (with suffix "_vmax.txt") obtained using the maximum posterior estimate for the gene-variances $v_g$, rather than integrating over the posterior of $v_g$. This is the most correct output when one wants to reconstruct the likelihood expression from the posterior estimates, for example in the distance-calculation script. (string, `'true', 'false', '1', '0'` or `'only_max_output'`, default: `false`)
 * (optional) Minimal and maximal considered values of the variance in log transcription quotients (double, default: *v<sub>min</sub>=*`0.001` *v<sub>max</sub>=*`50`)
 * (optional) Number of bins for the variance in log transcription quotients (integer, default: `160`)
 * (optional) Option to skip cell size normalization (Boolean, `'true', 'false', '1'` or `'0'`, default: `false`)
@@ -52,6 +53,9 @@ The scripts used for running the bechmarked normalization methods and for making
   | Gene 2 | 0.315551 | 0.325912 | 0.301861 |
   | ... | |
 
+* (optional) log_transcription_quotients_vmax.txt: Analogous file to log_transcription_quotients.txt but reporting the LTQs obtained by using the maximum-posterior gene-variance $v_g$. This file is only produced when `-max v` is set to `true` or `only_max_output`.
+* (optional) ltq_error_bars_vmax.txt: See the description for log_transcription_quotients_vmax.txt.
+
 ## Extended output (optional)
 
 * mu.txt : Estimated average LTQ *&mu;<sub>g</sub>* of each gene *g* (averaged over all cells)
@@ -59,6 +63,7 @@ The scripts used for running the bechmarked normalization methods and for making
 * variance.txt : Estimated variance of the LTQs *x<sub>gc</sub>* across cells *c* for each gene *g*. Note that these variances are different, and generally larger, than what one would obtain when directly calculating the variance of the estimates of *x<sub>gc</sub>* from the file log_transcription_quotients.txt. This is because the estimates in this file take into account the uncertainty on the estimates of the *x<sub>gc</sub>*. Thus, when estimates of true gene expression variability are needed, you are strongly adviced to use the results in this file.
 * delta.txt : Matrix of inferred log-fold changes *&delta;<sub>gc</sub> = x<sub>gc</sub>-&mu;<sub>g</sub>* for each gene *g* in each cell *c*.
 * d_delta.txt : Matrix of error-bars for the inferred log fold-changes *&delta;<sub>gc</sub>*.
+* ..._vmax.txt: All the above files will be obtained with a `_vmax.txt`-suffix when `-max v` is set to `true` or `only_max_output`.
 * likelihood.txt : This file encodes the posterior distribution of each gene’s true variance in log-expression. For the numerical calculation of this distribution, the variance is a prior assumed to lie in the range *[v<sub>min</sub>,v<sub>max</sub>]* and is discretized into *N<sub>b</sub>* bins uniformly on a logarithmic scale. The file contains the matrix with posterior values *P<sub>gb</sub>* for each gene *g* and each bin *b*.
 
   | | | | | |
@@ -80,6 +85,7 @@ The scripts used for running the bechmarked normalization methods and for making
 	-d,--destination	Specify the destination path (default: pwd)
 	-n,--n_threads		Specify the number of threads to be used (default: 4)
 	-e,--extended_output	Option to print extended output (default: false, choice: false,0,true,1)
+	-max_v,--get_output_for_maxlik_variance	Option to obtain additional output obtained for maximum-posterior gene-variance (default: false, choice: false,0,true,1,only_max_output)
 	-vmin,--variance_min	Minimal value of variance in log transcription quotient (default: 0.001)
 	-vmax,--variance_max	Maximal value of variance in log transcription quotient (default: 50)
 	-nbin,--number_of_bins	Number of bins for the variance in log transcription quotient  (default: 160)

--- a/src/ReadInputFiles.cpp
+++ b/src/ReadInputFiles.cpp
@@ -141,7 +141,7 @@ void ReadUMIcountMatrix(string in_file, double **n_c, double *N_c, double *n, st
             /****go to the next in the list of words****/
             token = strtok(NULL," \t,");
             if(token != NULL){
-                n_c_tmp[c] = atoi(token);
+                n_c_tmp[c] = stod(token);
                 n_tmp += n_c_tmp[c];// total count this gene
                 N_c[c] += n_c_tmp[c];// total count for this cell
             }else{
@@ -328,7 +328,7 @@ void ReadMTX(string mtx_file, string gene_name_file, string cell_name_file, doub
 		token = strtok(NULL," ");
 		c = atoi(token);
 		token = strtok(NULL," ");
-		count = atoi(token);
+		count = stod(token);
 
 		g = g-1;
 		c = c-1;

--- a/src/ReadInputFiles.cpp
+++ b/src/ReadInputFiles.cpp
@@ -55,7 +55,7 @@ void Get_G_C_UMIcountMatrix(string in_file, int &N_rows, int &G, int &C, int N_c
             /****go to the next in the list of words****/
             token = strtok(NULL," \t,");
             if(token != NULL){
-                n += atoi(token);/**total count this gene**/
+                n += stod(token);/**total count this gene**/
             }else{
                 fprintf(stderr,"Error: not enough fields on line number %d:\n%s\n",g,sc);
                 exit(EXIT_FAILURE);
@@ -193,10 +193,10 @@ void Get_G_C_MTX(string in_file, int &N_rows, int &G, int &C, map<int,int> &gene
 		}else{
 			token = strtok(retval," ");
 			// Highest number of genes expressed and not
-			N_rows = atoi(token);
+			N_rows = stoi(token);
 			token = strtok(NULL," \t");
 			// Number of cells
-			C = atoi(token);
+			C = stoi(token);
 			break;
 		}
 	}
@@ -212,7 +212,7 @@ void Get_G_C_MTX(string in_file, int &N_rows, int &G, int &C, map<int,int> &gene
     while ( (retval = fgets(ss,1024,infp) ) != NULL) {
 		// Read values gene idx and add as expressed
 		token = strtok(retval," \t");
-		g = atoi(token);
+		g = stoi(token);
 		g=g-1;
 		// Update gene_idx map and count gene if not seen before
 		if( ! expressed_genes[g] ){
@@ -324,9 +324,9 @@ void ReadMTX(string mtx_file, string gene_name_file, string cell_name_file, doub
     while ( (retval = fgets(ss,1024,infp) ) != NULL) {
 		// Read values gene idx and add as expressed
 		token = strtok(retval," ");
-		g = atoi(token);
+		g = stoi(token);
 		token = strtok(NULL," ");
-		c = atoi(token);
+		c = stoi(token);
 		token = strtok(NULL," ");
 		count = stod(token);
 

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -411,8 +411,8 @@ int main (int argc, char** argv){
 	// Repeat very similar output code for when you want to output the results for max posterior v_g
 	if (max_v_output){
 		ofstream out_exp_lev_v_ml, out_d_exp_lev_v_ml;
-		out_exp_lev_v_ml.open(out_subfolder + "log_transcription_quotients_v_ml.txt",ios::out);
-		out_d_exp_lev_v_ml.open(out_subfolder + "ltq_error_bars_v_ml.txt",ios::out);
+		out_exp_lev_v_ml.open(out_subfolder + "log_transcription_quotients.txt",ios::out);
+		out_d_exp_lev_v_ml.open(out_subfolder + "ltq_error_bars.txt",ios::out);
 
 		out_exp_lev_v_ml << "GeneID";
 		out_d_exp_lev_v_ml << "GeneID";
@@ -458,35 +458,35 @@ int main (int argc, char** argv){
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "mu_v_ml.txt";
+			my_file = out_subfolder + "mu.txt";
 			out_mu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_mu_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "d_mu_v_ml.txt";
+			my_file = out_subfolder + "d_mu.txt";
 			out_dmu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_dmu_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "variance_v_ml.txt";
+			my_file = out_subfolder + "variance.txt";
 			out_var_gene_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_var_gene_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "delta_v_ml.txt";
+			my_file = out_subfolder + "delta.txt";
 			out_delta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_delta_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "d_delta_v_ml.txt";
+			my_file = out_subfolder + "d_delta.txt";
 			out_ddelta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_ddelta_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -493,16 +493,13 @@ int main (int argc, char** argv){
 				exit(EXIT_FAILURE);
 			}
 
-			if(!post_v_output){
-				for(c=0;c<C;c++){
-					fprintf(out_cell,"%s\n",cell_names[c].c_str());
-				}
+
+			for(c=0;c<C;c++){
+				fprintf(out_cell,"%s\n",cell_names[c].c_str());
 			}
 			for(g=0; g<G; ++g){
 				// Write gene names
-				if(!post_v_output){
-					fprintf(out_gene,"%s\n",gene_names[g].c_str());
-				}
+				fprintf(out_gene,"%s\n",gene_names[g].c_str());
 				//print best fit to file : mu, delta
 				// Print diagonal of invM : variance of mu, delta
 				fprintf(out_mu_v_ml,"%lf\n",mu_v_ml[g]);

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -167,9 +167,7 @@ int main (int argc, char** argv){
 
 		// run on N_est genes
 		for(g=0;g<N_est;++g){
-			cout << "gene: " << g << endl;
 			get_gene_expression_level(n_c[g],N_c,n[g],vmin,vmax,mu[g],var_mu[g],delta[g],var_delta[g],C,numbin,a,b,lik[g], var_gene_v_ml[g], mu_v_ml[g], var_mu_v_ml[g], delta_v_ml[g], var_delta_v_ml[g]);
-			if (g == 1){exit(0);}
 		}
 
 		// stop timer
@@ -204,7 +202,6 @@ int main (int argc, char** argv){
 			fprintf(stderr, "First process now fitting gene %d out of %d.\n", g, (int) G/N_threads);
 			g_print *= 2;
 		}
-		cout << "gene: " << g << endl;
 		get_gene_expression_level(n_c[g],N_c,n[g],vmin,vmax,mu[g],var_mu[g],delta[g],var_delta[g],C,numbin,a,b,lik[g], var_gene_v_ml[g], mu_v_ml[g], var_mu_v_ml[g], delta_v_ml[g], var_delta_v_ml[g]);
 	}
 

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -411,8 +411,8 @@ int main (int argc, char** argv){
 	// Repeat very similar output code for when you want to output the results for max posterior v_g
 	if (max_v_output){
 		ofstream out_exp_lev_v_ml, out_d_exp_lev_v_ml;
-		out_exp_lev_v_ml.open(out_subfolder + "log_transcription_quotients.txt",ios::out);
-		out_d_exp_lev_v_ml.open(out_subfolder + "ltq_error_bars.txt",ios::out);
+		out_exp_lev_v_ml.open(out_subfolder + "log_transcription_quotients_v_ml.txt",ios::out);
+		out_d_exp_lev_v_ml.open(out_subfolder + "ltq_error_bars_v_ml.txt",ios::out);
 
 		out_exp_lev_v_ml << "GeneID";
 		out_d_exp_lev_v_ml << "GeneID";
@@ -458,35 +458,35 @@ int main (int argc, char** argv){
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "mu.txt";
+			my_file = out_subfolder + "mu_v_ml.txt";
 			out_mu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_mu_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "d_mu.txt";
+			my_file = out_subfolder + "d_mu_v_ml.txt";
 			out_dmu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_dmu_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "variance.txt";
+			my_file = out_subfolder + "variance_v_ml.txt";
 			out_var_gene_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_var_gene_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "delta.txt";
+			my_file = out_subfolder + "delta_v_ml.txt";
 			out_delta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_delta_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "d_delta.txt";
+			my_file = out_subfolder + "d_delta_v_ml.txt";
 			out_ddelta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_ddelta_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -167,7 +167,9 @@ int main (int argc, char** argv){
 
 		// run on N_est genes
 		for(g=0;g<N_est;++g){
+			cout << "gene: " << g << endl;
 			get_gene_expression_level(n_c[g],N_c,n[g],vmin,vmax,mu[g],var_mu[g],delta[g],var_delta[g],C,numbin,a,b,lik[g], var_gene_v_ml[g], mu_v_ml[g], var_mu_v_ml[g], delta_v_ml[g], var_delta_v_ml[g]);
+			if (g == 1){exit(0);}
 		}
 
 		// stop timer
@@ -202,6 +204,7 @@ int main (int argc, char** argv){
 			fprintf(stderr, "First process now fitting gene %d out of %d.\n", g, (int) G/N_threads);
 			g_print *= 2;
 		}
+		cout << "gene: " << g << endl;
 		get_gene_expression_level(n_c[g],N_c,n[g],vmin,vmax,mu[g],var_mu[g],delta[g],var_delta[g],C,numbin,a,b,lik[g], var_gene_v_ml[g], mu_v_ml[g], var_mu_v_ml[g], delta_v_ml[g], var_delta_v_ml[g]);
 	}
 
@@ -557,7 +560,7 @@ void get_gene_expression_level(double *n_c, double *N_c, double n, double vmin, 
 	}
 
 	// Compute var_delta = < (mu - <mu>)^2 > + <d_mu>
-	var_mu = Psi_1((double) n);
+	var_mu = Psi_1((double) n + 1);
 	for(k=0;k<numbin;k++){
 		var_mu += lik[k]*(mu_v[k] - mu)*(mu_v[k] - mu);
 	}
@@ -583,7 +586,7 @@ void get_gene_expression_level(double *n_c, double *N_c, double n, double vmin, 
 	var_gene_v_ml = vmin * exp(deltav*Lmax_ind);
 	// And then also the corresponding values for the LTQs etc.
 	mu_v_ml = mu_v[Lmax_ind];
-	var_mu_v_ml = var_mu;
+	var_mu_v_ml = Psi_1((double) n + 1);
 	for(i=0;i<C;i++){
 		delta_v_ml[i] = delta_v[Lmax_ind][i];
 	}

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -125,7 +125,7 @@ int main (int argc, char** argv){
 	//
 	double usage_bytes = 1.1*(4*G + C + 3*G*C + G*numbin + (5*C + numbin + 2*C*numbin)*N_threads  )*size_of_double;
 	if (max_v_output && post_v_output){
-		usage_bytes *= 2;
+		usage_bytes *= 4;
 	}
 
 	cerr << std::setprecision(3);

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -248,15 +248,15 @@ int main (int argc, char** argv){
 	}
 
 	// Create subfolder if results need to be stored that take the maximum posterior value for v_g
-	string out_subfolder = "";
-	if (max_v_output){
-		out_subfolder = out_folder + "/using_max_posterior_v_g/";
-		#ifdef _WIN32
-			_mkdir(out_subfolder.c_str());  // Use _mkdir on Windows
-		#else
-			mkdir(out_subfolder.c_str(), 0777);  // Use mkdir on Unix-like systems with full permissions
-		#endif
-	}
+	// string out_subfolder = "";
+	// if (max_v_output){
+	// 	out_subfolder = out_folder + "/using_max_posterior_v_g/";
+	// 	#ifdef _WIN32
+	// 		_mkdir(out_subfolder.c_str());  // Use _mkdir on Windows
+	// 	#else
+	// 		mkdir(out_subfolder.c_str(), 0777);  // Use mkdir on Unix-like systems with full permissions
+	// 	#endif
+	// }
 
 	// Write output files
 
@@ -411,8 +411,8 @@ int main (int argc, char** argv){
 	// Repeat very similar output code for when you want to output the results for max posterior v_g
 	if (max_v_output){
 		ofstream out_exp_lev_v_ml, out_d_exp_lev_v_ml;
-		out_exp_lev_v_ml.open(out_subfolder + "log_transcription_quotients_v_ml.txt",ios::out);
-		out_d_exp_lev_v_ml.open(out_subfolder + "ltq_error_bars_v_ml.txt",ios::out);
+		out_exp_lev_v_ml.open(out_folder + "log_transcription_quotients_vmax.txt",ios::out);
+		out_d_exp_lev_v_ml.open(out_folder + "ltq_error_bars_vmax.txt",ios::out);
 
 		out_exp_lev_v_ml << "GeneID";
 		out_d_exp_lev_v_ml << "GeneID";
@@ -441,66 +441,68 @@ int main (int argc, char** argv){
 		if ( print_extended_output ){
 			cerr << "Print extended output\n";
 			string my_file;
-			FILE *out_gene_v_ml, *out_cell_v_ml;
+			FILE *out_gene, *out_cell;
 			FILE *out_mu_v_ml, *out_dmu_v_ml, *out_var_gene_v_ml, *out_delta_v_ml, *out_ddelta_v_ml;
-			// output files
-			my_file = out_subfolder + "geneID.txt";
-			out_gene_v_ml = (FILE *) fopen(my_file.c_str(),"w");
-			if(out_gene_v_ml == NULL){
-				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-				exit(EXIT_FAILURE);
-			}
+			if(!post_v_output){
+				my_file = out_folder + "geneID.txt";
+				out_gene = (FILE *) fopen(my_file.c_str(),"w");
+				if(out_gene == NULL){
+					fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+					exit(EXIT_FAILURE);
+				}
 
-			my_file = out_subfolder + "cellID.txt";
-			out_cell_v_ml = (FILE *) fopen(my_file.c_str(),"w");
-			if(out_cell_v_ml == NULL){
-				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-				exit(EXIT_FAILURE);
+				my_file = out_folder + "cellID.txt";
+				out_cell = (FILE *) fopen(my_file.c_str(),"w");
+				if(out_cell == NULL){
+					fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+					exit(EXIT_FAILURE);
+				}
 			}
-
-			my_file = out_subfolder + "mu_v_ml.txt";
+			my_file = out_folder + "mu_vmax.txt";
 			out_mu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_mu_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "d_mu_v_ml.txt";
+			my_file = out_folder + "d_mu_vmax.txt";
 			out_dmu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_dmu_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "variance_v_ml.txt";
+			my_file = out_folder + "variance_vmax.txt";
 			out_var_gene_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_var_gene_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "delta_v_ml.txt";
+			my_file = out_folder + "delta_vmax.txt";
 			out_delta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_delta_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-			my_file = out_subfolder + "d_delta_v_ml.txt";
+			my_file = out_folder + "d_delta_vmax.txt";
 			out_ddelta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
 			if(out_ddelta_v_ml == NULL){
 				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
 				exit(EXIT_FAILURE);
 			}
 
-
-			// output cell name
-			for(c=0;c<C;c++){
-				fprintf(out_cell_v_ml,"%s\n",cell_names[c].c_str());
+			if(!post_v_output){
+				for(c=0;c<C;c++){
+					fprintf(out_cell,"%s\n",cell_names[c].c_str());
+				}
 			}
 			for(g=0; g<G; ++g){
 				// Write gene names
-				fprintf(out_gene_v_ml,"%s\n",gene_names[g].c_str());
+				if(!post_v_output){
+					fprintf(out_gene,"%s\n",gene_names[g].c_str());
+				}
 				//print best fit to file : mu, delta
 				// Print diagonal of invM : variance of mu, delta
 				fprintf(out_mu_v_ml,"%lf\n",mu_v_ml[g]);

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -124,6 +124,9 @@ int main (int argc, char** argv){
 	//
 	//
 	double usage_bytes = 1.1*(4*G + C + 3*G*C + G*numbin + (5*C + numbin + 2*C*numbin)*N_threads  )*size_of_double;
+	if (max_v_output && post_v_output){
+		usage_bytes *= 2;
+	}
 
 	cerr << std::setprecision(3);
 	cerr << "Estimated memory usage: ";
@@ -134,15 +137,20 @@ int main (int argc, char** argv){
 	}else{
 		cerr << usage_bytes/1e3 << " KB\n";
 	}
-    // Declare output variable
+    // Declare output variables
 	double *mu = new double [G];
 	double *var_mu = new double [G];
 	double *var_gene = new double [G];
-	double **delta = new double *[G];
-	double **var_delta = new double *[G];
-	for( g=0; g<G; ++g){
-		delta[g] = new double [C];
-		var_delta[g] = new double [C];
+	
+	double **delta = nullptr;
+	double **var_delta = nullptr;
+	if (post_v_output){
+		delta = new double *[G];
+		var_delta = new double *[G];
+		for( g=0; g<G; ++g){
+			delta[g] = new double [C];
+			var_delta[g] = new double [C];
+		}
 	}
 	double v;
 	double deltav = log(vmax/vmin)/((double) numbin-1);
@@ -154,15 +162,27 @@ int main (int argc, char** argv){
 	}
 
 	// Declare output variables for when we want to store results for maximum likelihood estimate for v_g
-	double *var_gene_v_ml = new double [G];
-	double *mu_v_ml = new double [G];
-	double *var_mu_v_ml = new double [G];
-	double **delta_v_ml = new double *[G];
-	double **var_delta_v_ml = new double *[G];
-	for( g=0; g<G; ++g){
-		delta_v_ml[g] = new double [C];
-		var_delta_v_ml[g] = new double [C];
+	double *var_gene_v_ml = nullptr;
+	double *mu_v_ml = nullptr;
+	double *var_mu_v_ml = nullptr;
+	double **delta_v_ml = nullptr;
+	double **var_delta_v_ml = nullptr;
+	if (max_v_output){
+		var_gene_v_ml = new double [G];
+		mu_v_ml = new double [G];
+		var_mu_v_ml = new double [G];
+		delta_v_ml = new double *[G];
+		var_delta_v_ml = new double *[G];
+		for( g=0; g<G; ++g){
+			delta_v_ml[g] = new double [C];
+			var_delta_v_ml[g] = new double [C];
+		}
 	}
+
+	double* row_delta = nullptr;
+	double* row_var_delta = nullptr;
+	double* row_delta_v_ml = nullptr;
+	double* row_var_delta_v_ml = nullptr;
 
 	// Estimate running time:
 	int N_est = 10;
@@ -172,7 +192,15 @@ int main (int argc, char** argv){
 
 		// run on N_est genes
 		for(g=0;g<N_est;++g){
-			get_gene_expression_level(n_c[g],N_c,n[g],vmin,vmax,mu[g],var_mu[g],delta[g],var_delta[g],C,numbin,a,b,lik[g], var_gene_v_ml[g], mu_v_ml[g], var_mu_v_ml[g], delta_v_ml[g], var_delta_v_ml[g]);
+			if (post_v_output){
+				row_delta = delta[g];
+				row_var_delta = var_delta[g];
+			}
+			if (max_v_output){
+				row_delta_v_ml = delta_v_ml[g];
+				row_var_delta_v_ml = var_delta_v_ml[g];
+			}
+			get_gene_expression_level(n_c[g],N_c,n[g],vmin,vmax,mu[g],var_mu[g],row_delta,row_var_delta,C,numbin,a,b,lik[g], var_gene_v_ml[g], mu_v_ml[g], var_mu_v_ml[g], row_delta_v_ml, row_var_delta_v_ml);
 		}
 
 		// stop timer
@@ -207,236 +235,290 @@ int main (int argc, char** argv){
 			fprintf(stderr, "First process now fitting gene %d out of %d.\n", g, (int) G/N_threads);
 			g_print *= 2;
 		}
-		get_gene_expression_level(n_c[g],N_c,n[g],vmin,vmax,mu[g],var_mu[g],delta[g],var_delta[g],C,numbin,a,b,lik[g], var_gene_v_ml[g], mu_v_ml[g], var_mu_v_ml[g], delta_v_ml[g], var_delta_v_ml[g]);
+
+		if (post_v_output){
+			row_delta = delta[g];
+			row_var_delta = var_delta[g];
+		}
+		if (max_v_output){
+			row_delta_v_ml = delta_v_ml[g];
+			row_var_delta_v_ml = var_delta_v_ml[g];
+		}
+		get_gene_expression_level(n_c[g],N_c,n[g],vmin,vmax,mu[g],var_mu[g],row_delta,row_var_delta,C,numbin,a,b,lik[g], var_gene_v_ml[g], mu_v_ml[g], var_mu_v_ml[g], row_delta_v_ml, row_var_delta_v_ml);
 	}
 
 	// Create subfolder if results need to be stored that take the maximum posterior value for v_g
-	string out_subfolder = out_folder + "/using_max_posterior_v_g/";
-	#ifdef _WIN32
-    	_mkdir(out_subfolder.c_str());  // Use _mkdir on Windows
-	#else
-    	mkdir(out_subfolder.c_str(), 0777);  // Use mkdir on Unix-like systems with full permissions
-	#endif
+	string out_subfolder = "";
+	if (max_v_output){
+		out_subfolder = out_folder + "/using_max_posterior_v_g/";
+		#ifdef _WIN32
+			_mkdir(out_subfolder.c_str());  // Use _mkdir on Windows
+		#else
+			mkdir(out_subfolder.c_str(), 0777);  // Use mkdir on Unix-like systems with full permissions
+		#endif
+	}
 
 	// Write output files
 
 	cerr << "Print output\n";
 	// Write log expression table and error bars table
-	ofstream out_exp_lev, out_d_exp_lev, out_exp_lev_v_ml, out_d_exp_lev_v_ml;
-	out_exp_lev.open(out_folder + "log_transcription_quotients.txt",ios::out);
-	out_d_exp_lev.open(out_folder + "ltq_error_bars.txt",ios::out);
-	out_exp_lev_v_ml.open(out_subfolder + "log_transcription_quotients_v_ml.txt",ios::out);
-	out_d_exp_lev_v_ml.open(out_subfolder + "ltq_error_bars_v_ml.txt",ios::out);
+	if (post_v_output){
+		ofstream out_exp_lev, out_d_exp_lev, out_exp_lev_v_ml, out_d_exp_lev_v_ml;
+		out_exp_lev.open(out_folder + "log_transcription_quotients.txt",ios::out);
+		out_d_exp_lev.open(out_folder + "ltq_error_bars.txt",ios::out);
 
-	out_exp_lev << "GeneID";
-	out_d_exp_lev << "GeneID";
-	out_exp_lev_v_ml << "GeneID";
-	out_d_exp_lev_v_ml << "GeneID";
-    for(c=0;c<C;c++){
-		out_exp_lev << "\t" << cell_names[c].c_str();
-		out_d_exp_lev << "\t" << cell_names[c].c_str();
-		out_exp_lev_v_ml << "\t" << cell_names[c].c_str();
-		out_d_exp_lev_v_ml << "\t" << cell_names[c].c_str();
-	}
-	out_exp_lev << "\n";
-	out_d_exp_lev << "\n";
-	out_exp_lev_v_ml << "\n";
-	out_d_exp_lev_v_ml << "\n";
-
-	for(g=0;g<G;g++){
-	out_exp_lev << gene_names[g].c_str();
-	out_d_exp_lev << gene_names[g].c_str();
-	out_exp_lev_v_ml << gene_names[g].c_str();
-	out_d_exp_lev_v_ml << gene_names[g].c_str();
+		out_exp_lev << "GeneID";
+		out_d_exp_lev << "GeneID";
 		for(c=0;c<C;c++){
-			out_exp_lev << "\t" << mu[g] + delta[g][c];
-			out_d_exp_lev << "\t" << sqrt( var_mu[g] + var_delta[g][c] );
-			out_exp_lev_v_ml << "\t" << mu_v_ml[g] + delta_v_ml[g][c];
-			out_d_exp_lev_v_ml << "\t" << sqrt( var_mu_v_ml[g] + var_delta_v_ml[g][c] );
+			out_exp_lev << "\t" << cell_names[c].c_str();
+			out_d_exp_lev << "\t" << cell_names[c].c_str();
 		}
-		if ( g != G-1 ){
-			out_exp_lev << "\n";
-			out_d_exp_lev << "\n";
-			out_exp_lev_v_ml << "\n";
-			out_d_exp_lev_v_ml << "\n";
-		}
-	}
-	out_exp_lev.close();
-	out_d_exp_lev.close();
-	out_exp_lev_v_ml.close();
-	out_d_exp_lev_v_ml.close();
+		out_exp_lev << "\n";
+		out_d_exp_lev << "\n";
 
-	if ( print_extended_output ){
-
-		// Compute variance : \int v*p(v) dv
-        for(g=0; g<G; ++g){
-			var_gene[g] = 0.0;
-			for(k=0;k<numbin;++k){
-				v = vmin * exp(deltav*k);
-				var_gene[g] += v*lik[g][k];
+		for(g=0;g<G;g++){
+		out_exp_lev << gene_names[g].c_str();
+		out_d_exp_lev << gene_names[g].c_str();
+			for(c=0;c<C;c++){
+				out_exp_lev << "\t" << mu[g] + delta[g][c];
+				out_d_exp_lev << "\t" << sqrt( var_mu[g] + var_delta[g][c] );
+			}
+			if ( g != G-1 ){
+				out_exp_lev << "\n";
+				out_d_exp_lev << "\n";
 			}
 		}
+		out_exp_lev.close();
+		out_d_exp_lev.close();
 
-		cerr << "Print extended output\n";
-		string my_file;
-		FILE *out_gene, *out_cell, *out_mu, *out_dmu, *out_var_gene, *out_delta, *out_ddelta;
-		FILE *out_mu_v_ml, *out_dmu_v_ml, *out_var_gene_v_ml, *out_delta_v_ml, *out_ddelta_sq_v_ml;
-		// output files
-		my_file = out_folder + "geneID.txt";
-		out_gene = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_gene == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
+		if ( print_extended_output ){
 
-		my_file = out_folder + "cellID.txt";
-		out_cell = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_cell == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_folder + "mu.txt";
-		out_mu = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_mu == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_folder + "d_mu.txt";
-		out_dmu = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_dmu == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_folder + "variance.txt";
-		out_var_gene = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_var_gene == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_folder + "delta.txt";
-		out_delta = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_delta == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_folder + "d_delta.txt";
-		out_ddelta = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_ddelta == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_subfolder + "mu_v_ml.txt";
-		out_mu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_mu_v_ml == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_subfolder + "d_mu_v_ml.txt";
-		out_dmu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_dmu_v_ml == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_subfolder + "variance_v_ml.txt";
-		out_var_gene_v_ml = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_var_gene_v_ml == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_subfolder + "delta_v_ml.txt";
-		out_delta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_delta_v_ml == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-		my_file = out_subfolder + "d_delta_sq_v_ml.txt";
-		out_ddelta_sq_v_ml = (FILE *) fopen(my_file.c_str(),"w");
-		if(out_ddelta_sq_v_ml == NULL){
-			fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
-			exit(EXIT_FAILURE);
-		}
-
-
-		// output cell name
-		for(c=0;c<C;c++){
-			fprintf(out_cell,"%s\n",cell_names[c].c_str());
-		}
-		for(g=0; g<G; ++g){
-			// Write gene names
-			fprintf(out_gene,"%s\n",gene_names[g].c_str());
-
-			//print best fit to file : mu, delta
-			// Print diagonal of invM : variance of mu, delta
-			fprintf(out_mu,"%lf\n",mu[g]);
-			fprintf(out_dmu,"%lf\n",sqrt(var_mu[g]));
-			fprintf(out_var_gene,"%lf\n",var_gene[g]);
-			for(c=0;c<C-1;++c){
-				fprintf(out_delta,"%lf\t",delta[g][c]);
-				fprintf(out_ddelta,"%lf\t",sqrt(var_delta[g][c]));
-			}
-			fprintf(out_delta,"%lf\n",delta[g][C-1]);
-			fprintf(out_ddelta,"%lf\n",sqrt(var_delta[g][C-1]));
-		}
-		fclose(out_gene);
-		fclose(out_cell);
-		fclose(out_mu);
-		fclose(out_dmu);
-		fclose(out_var_gene);
-		fclose(out_delta);
-		fclose(out_ddelta);
-
-		// Output results if gene-variance (v_g) is fixed to its maximum likelihood estimate
-		for(g=0; g<G; ++g){
-			//print best fit to file : mu, delta
-			// Print diagonal of invM : variance of mu, delta
-			fprintf(out_mu_v_ml,"%lf\n",mu_v_ml[g]);
-			fprintf(out_dmu_v_ml,"%lf\n",sqrt(var_mu_v_ml[g]));
-			fprintf(out_var_gene_v_ml,"%lf\n",var_gene_v_ml[g]);
-			for(c=0;c<C-1;++c){
-				fprintf(out_delta_sq_v_ml,"%lf\t",delta_v_ml[g][c]);
-				fprintf(out_ddelta_sq_v_ml,"%lf\t",var_delta_v_ml[g][c]);
-			}
-			fprintf(out_delta_v_ml,"%lf\n",delta_v_ml[g][C-1]);
-			fprintf(out_ddelta_sq_v_ml,"%lf\n", var_delta_v_ml[g][C-1]);
-		}
-		fclose(out_mu_v_ml);
-		fclose(out_dmu_v_ml);
-		fclose(out_var_gene_v_ml);
-		fclose(out_delta_v_ml);
-		fclose(out_ddelta_sq_v_ml);
-
-		// Write likelihood
-		ofstream out_lik;
-		out_lik.open(out_folder + "likelihood.txt",ios::out);
-		// write v values of bins in loglikelihood
-		out_lik << "Variance\t";
-		for(k=0;k<(numbin-1);++k){
-			v = vmin*exp(deltav*k);
-			out_lik << v << "\t";
-		}
-		v = vmin*exp(deltav*(numbin-1));
-		out_lik << v << "\n";
-		for(g=0; g<G; ++g){
-			out_lik << gene_names[g] << "\t";
-			for(k=0;k<numbin;++k){
-				if(k<numbin-1){
-					out_lik << lik[g][k] << "\t";
-				}else{
-					out_lik << lik[g][k] << "\n";
+			// Compute variance : \int v*p(v) dv
+			for(g=0; g<G; ++g){
+				var_gene[g] = 0.0;
+				for(k=0;k<numbin;++k){
+					v = vmin * exp(deltav*k);
+					var_gene[g] += v*lik[g][k];
 				}
 			}
+
+			cerr << "Print extended output\n";
+			string my_file;
+			FILE *out_gene, *out_cell, *out_mu, *out_dmu, *out_var_gene, *out_delta, *out_ddelta;
+			// output files
+			my_file = out_folder + "geneID.txt";
+			out_gene = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_gene == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_folder + "cellID.txt";
+			out_cell = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_cell == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_folder + "mu.txt";
+			out_mu = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_mu == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_folder + "d_mu.txt";
+			out_dmu = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_dmu == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_folder + "variance.txt";
+			out_var_gene = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_var_gene == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_folder + "delta.txt";
+			out_delta = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_delta == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_folder + "d_delta.txt";
+			out_ddelta = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_ddelta == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			// output cell name
+			for(c=0;c<C;c++){
+				fprintf(out_cell,"%s\n",cell_names[c].c_str());
+			}
+			for(g=0; g<G; ++g){
+				// Write gene names
+				fprintf(out_gene,"%s\n",gene_names[g].c_str());
+
+				//print best fit to file : mu, delta
+				// Print diagonal of invM : variance of mu, delta
+				fprintf(out_mu,"%lf\n",mu[g]);
+				fprintf(out_dmu,"%lf\n",sqrt(var_mu[g]));
+				fprintf(out_var_gene,"%lf\n",var_gene[g]);
+				for(c=0;c<C-1;++c){
+					fprintf(out_delta,"%lf\t",delta[g][c]);
+					fprintf(out_ddelta,"%lf\t",sqrt(var_delta[g][c]));
+				}
+				fprintf(out_delta,"%lf\n",delta[g][C-1]);
+				fprintf(out_ddelta,"%lf\n",sqrt(var_delta[g][C-1]));
+			}
+			fclose(out_gene);
+			fclose(out_cell);
+			fclose(out_mu);
+			fclose(out_dmu);
+			fclose(out_var_gene);
+			fclose(out_delta);
+			fclose(out_ddelta);
+
+			// Write likelihood
+			ofstream out_lik;
+			out_lik.open(out_folder + "likelihood.txt",ios::out);
+			// write v values of bins in loglikelihood
+			out_lik << "Variance\t";
+			for(k=0;k<(numbin-1);++k){
+				v = vmin*exp(deltav*k);
+				out_lik << v << "\t";
+			}
+			v = vmin*exp(deltav*(numbin-1));
+			out_lik << v << "\n";
+			for(g=0; g<G; ++g){
+				out_lik << gene_names[g] << "\t";
+				for(k=0;k<numbin;++k){
+					if(k<numbin-1){
+						out_lik << lik[g][k] << "\t";
+					}else{
+						out_lik << lik[g][k] << "\n";
+					}
+				}
+			}
+			out_lik.close();
 		}
-		out_lik.close();
+	}
+	
+	// Repeat very similar output code for when you want to output the results for max posterior v_g
+	if (max_v_output){
+		ofstream out_exp_lev_v_ml, out_d_exp_lev_v_ml;
+		out_exp_lev_v_ml.open(out_subfolder + "log_transcription_quotients_v_ml.txt",ios::out);
+		out_d_exp_lev_v_ml.open(out_subfolder + "ltq_error_bars_v_ml.txt",ios::out);
+
+		out_exp_lev_v_ml << "GeneID";
+		out_d_exp_lev_v_ml << "GeneID";
+		for(c=0;c<C;c++){
+			out_exp_lev_v_ml << "\t" << cell_names[c].c_str();
+			out_d_exp_lev_v_ml << "\t" << cell_names[c].c_str();
+		}
+		out_exp_lev_v_ml << "\n";
+		out_d_exp_lev_v_ml << "\n";
+
+		for(g=0;g<G;g++){
+		out_exp_lev_v_ml << gene_names[g].c_str();
+		out_d_exp_lev_v_ml << gene_names[g].c_str();
+			for(c=0;c<C;c++){
+				out_exp_lev_v_ml << "\t" << mu_v_ml[g] + delta_v_ml[g][c];
+				out_d_exp_lev_v_ml << "\t" << sqrt( var_mu_v_ml[g] + var_delta_v_ml[g][c] );
+			}
+			if ( g != G-1 ){
+				out_exp_lev_v_ml << "\n";
+				out_d_exp_lev_v_ml << "\n";
+			}
+		}
+		out_exp_lev_v_ml.close();
+		out_d_exp_lev_v_ml.close();
+
+		if ( print_extended_output ){
+			cerr << "Print extended output\n";
+			string my_file;
+			FILE *out_gene_v_ml, *out_cell_v_ml;
+			FILE *out_mu_v_ml, *out_dmu_v_ml, *out_var_gene_v_ml, *out_delta_v_ml, *out_ddelta_v_ml;
+			// output files
+			my_file = out_subfolder + "geneID.txt";
+			out_gene_v_ml = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_gene_v_ml == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_subfolder + "cellID.txt";
+			out_cell_v_ml = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_cell_v_ml == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_subfolder + "mu_v_ml.txt";
+			out_mu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_mu_v_ml == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_subfolder + "d_mu_v_ml.txt";
+			out_dmu_v_ml = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_dmu_v_ml == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_subfolder + "variance_v_ml.txt";
+			out_var_gene_v_ml = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_var_gene_v_ml == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_subfolder + "delta_v_ml.txt";
+			out_delta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_delta_v_ml == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+			my_file = out_subfolder + "d_delta_v_ml.txt";
+			out_ddelta_v_ml = (FILE *) fopen(my_file.c_str(),"w");
+			if(out_ddelta_v_ml == NULL){
+				fprintf(stderr,"Cannot open output file %s\n",my_file.c_str());
+				exit(EXIT_FAILURE);
+			}
+
+
+			// output cell name
+			for(c=0;c<C;c++){
+				fprintf(out_cell_v_ml,"%s\n",cell_names[c].c_str());
+			}
+			for(g=0; g<G; ++g){
+				// Write gene names
+				fprintf(out_gene_v_ml,"%s\n",gene_names[g].c_str());
+				//print best fit to file : mu, delta
+				// Print diagonal of invM : variance of mu, delta
+				fprintf(out_mu_v_ml,"%lf\n",mu_v_ml[g]);
+				fprintf(out_dmu_v_ml,"%lf\n",sqrt(var_mu_v_ml[g]));
+				fprintf(out_var_gene_v_ml,"%lf\n",var_gene_v_ml[g]);
+				for(c=0;c<C-1;++c){
+					fprintf(out_delta_v_ml,"%lf\t",delta_v_ml[g][c]);
+					fprintf(out_ddelta_v_ml,"%lf\t",sqrt(var_delta_v_ml[g][c]));
+				}
+				fprintf(out_delta_v_ml,"%lf\n",delta_v_ml[g][C-1]);
+				fprintf(out_ddelta_v_ml,"%lf\n", sqrt(var_delta_v_ml[g][C-1]));
+			}
+			fclose(out_mu_v_ml);
+			fclose(out_dmu_v_ml);
+			fclose(out_var_gene_v_ml);
+			fclose(out_delta_v_ml);
+			fclose(out_ddelta_v_ml);
+		}
 	}
 
     return 0;
@@ -575,33 +657,35 @@ void get_gene_expression_level(double *n_c, double *N_c, double n, double vmin, 
 		var_mu += lik[k]*(mu_v[k] - mu)*(mu_v[k] - mu);
 	}
 
-	// Compute <delta> = int p(v)*delta(v) dv
-	for(i=0;i<C;i++){
-		delta[i] = 0.0;
-		for(k=0;k<numbin;k++){
-			delta[i] += lik[k]*delta_v[k][i];
+	if (delta != nullptr){
+		// Compute <delta> = int p(v)*delta(v) dv
+		for(i=0;i<C;i++){
+			delta[i] = 0.0;
+			for(k=0;k<numbin;k++){
+				delta[i] += lik[k]*delta_v[k][i];
+			}
+		}
+		// Compute var_delta = < (delta - <delta>)^2 > + <sig2_delta^2>
+		for(i=0;i<C;i++){
+			var_delta[i] = 0.0;
+			for(k=0;k<numbin;k++){
+				var_delta[i] += lik[k]*(delta_v[k][i]-delta[i])*(delta_v[k][i]-delta[i]) + lik[k]*sig2_delta_v[k][i];
+			}
 		}
 	}
 
-	// Compute var_delta = < (delta - <delta>)^2 > + <sig2_delta^2>
-	for(i=0;i<C;i++){
-		var_delta[i] = 0.0;
-		for(k=0;k<numbin;k++){
-			var_delta[i] += lik[k]*(delta_v[k][i]-delta[i])*(delta_v[k][i]-delta[i]) + lik[k]*sig2_delta_v[k][i];
+	if (delta_v_ml != nullptr){
+		// Store the gene-variance that maximizes the likelihood:
+		var_gene_v_ml = vmin * exp(deltav*Lmax_ind);
+		// And then also the corresponding values for the LTQs etc.
+		mu_v_ml = mu_v[Lmax_ind];
+		var_mu_v_ml = Psi_1((double) n + 1);
+		for(i=0;i<C;i++){
+			delta_v_ml[i] = delta_v[Lmax_ind][i];
 		}
-	}
-
-
-	// Store the gene-variance that maximizes the likelihood:
-	var_gene_v_ml = vmin * exp(deltav*Lmax_ind);
-	// And then also the corresponding values for the LTQs etc.
-	mu_v_ml = mu_v[Lmax_ind];
-	var_mu_v_ml = Psi_1((double) n + 1);
-	for(i=0;i<C;i++){
-		delta_v_ml[i] = delta_v[Lmax_ind][i];
-	}
-	for(i=0;i<C;i++){
-		var_delta_v_ml[i] = sig2_delta_v[Lmax_ind][i];
+		for(i=0;i<C;i++){
+			var_delta_v_ml[i] = sig2_delta_v[Lmax_ind][i];
+		}
 	}
 
 	delete[] f;
@@ -774,6 +858,8 @@ static void show_usage(void)
          << "\t-vmax,--variance_max\tMaximal value of variance in log transcription quotient (default: 50)\n"
          << "\t-nbin,--number_of_bins\tNumber of bins for the variance in log transcription quotient  (default: 160)\n"
 		 << "\t-no_norm,--no_cell_size_normalization\tOption to skip cell size normalization (default: false, choice: false,0,true,1)\n"
-		 << "\t-max_v,--get_output_for_maxlik_variance\tOption to also output all results for the prior variance (v_g) that maximizes the likelihood, i.e., without integrating over the posterior for v_g (default: false, choice: false,0,true,1,only_max_output)\n";
+		 << "\t-max_v,--get_output_for_maxlik_variance\tOption to also output all results for the prior variance (v_g) that maximizes the likelihood, \n\t"
+		 <<	"\ti.e., without integrating over the posterior for v_g.\n\t "
+		 <<	"\tChoose 'only_max_output' to get only output for the maximum posterior v_g. (default: false, choice: false,0,true,1,only_max_output)\n";
 	exit(0);
 }


### PR DESCRIPTION
This pull request comprises two things:
1. When using mtx-files in float-format, numbers are by default stored in scientific notation. For example `11` becomes `1.1E1`. The original reading of mtx-files in Sanity was using `atoi`, which was just reading this number until the first dot. An `11` thus became `1`. In this update, the atoi-functions are replaced by `stod`, which not only reads in all integers correctly, but also allows for having non-integer counts. The rest of the Sanity-code allows for non-integers.

2. I added a new mode for running _Sanity_. For some applications, it is useful to reconstruct the expression for the likelihood of the data, $P(D|x_{gc})$, as a function of the LTQ-values, rather than having the posteriors, $P(x_{gc}|D)$ that Sanity provides. For example, for the Sanity distance script. Therefore, we followed the expressions for dividing out the priors as described in the Sanity-paper. However, we found that, because the posterior-means and variances reported by Sanity are obtained by marginalizing over $v_g$, it could sometimes happen that dividing out the prior led to contradictory results. In particular, sometimes the error-bar on an LTQ, $\epsilon_{gc}^2$, was bigger than the true variance in that gene $v_g$. To avoid that problem, we have now added a mode that reports all normal outputs but now calculated with the maximum posterior $v_g$, rather than integrating over $v_g$.

By default, _Sanity_ is just run in the normal mode, but using a flag, `-max_v`, the user can now 1) get both the values for the marginalized $v_g$ *and* the maximal $v_g$, or 2) get only the results for the maximal $v_g$.