### PR TITLE
Bug fix where count-matrix is not initialized to zero

### DIFF
--- a/src/ReadInputFiles.cpp
+++ b/src/ReadInputFiles.cpp
@@ -242,7 +242,8 @@ void ReadMTX(string mtx_file, string gene_name_file, string cell_name_file, doub
 	char ss[1024];
 	char * retval = NULL;
 	char * token = NULL;
-	int g,c,count,tmp;
+	int g,c,tmp;
+    double count;
 
 	// Read gene_names
 	if ( gene_name_file != "none" ){

--- a/src/calc_true_variation_parallel_prior_mu_sigma.cpp
+++ b/src/calc_true_variation_parallel_prior_mu_sigma.cpp
@@ -71,7 +71,8 @@ int main (int argc, char** argv){
 	// count per gene and per cell
     double **n_c = new double *[G];
     for(g=0;g<G;++g){
-        n_c[g] = new double [C];
+        // n_c[g] = new double [C];
+		n_c[g] = new double[C]();
 		n[g] = 0;
 	}
 	// Gene and cell names


### PR DESCRIPTION
As far as I can see, the count matrix was nowhere explicitly initialized to be full of zeroes. This caused an issue when reading in from the sparse .mtx-format, because these values were nowhere over-written. (I had an issue where one of the entries in the matrix suddenly pointed to a very large integer).

If I understood this correctly, the fix in this Pull Request should help.